### PR TITLE
Issue12

### DIFF
--- a/src/SIL/Parser.hs
+++ b/src/SIL/Parser.hs
@@ -315,13 +315,21 @@ parseCompleteLambda = do
   scn
   return . TLam (Closed (Right $ head variables)) $ foldr (\n -> TLam (Open (Right n))) iexpr (tail variables)
 
+parseSameLvl :: Pos -> SILParser a -> SILParser a
+parseSameLvl pos parser = do
+  lvl <- L.indentLevel
+  case pos == lvl of
+    True -> parser
+    False -> fail "Expected same indentation"
+
 -- |Parse let expression.
 parseLet :: SILParser Term1
 parseLet = do
   reserved "let"
   initialState <- State.get
   scn
-  manyTill parseAssignment (reserved "in")
+  lvl <- L.indentLevel
+  manyTill (parseSameLvl lvl parseAssignment) (reserved "in")
   scn
   expr <- parseLongExpr
   scn

--- a/src/SIL/Parser.hs
+++ b/src/SIL/Parser.hs
@@ -369,7 +369,7 @@ parseAssignment = do
  -- |Parse top level expressions.
 parseTopLevel :: SILParser Bindings
 parseTopLevel = do
-  many parseAssignment <* eof
+  scn *> many parseAssignment <* eof
   (ParserState bound) <- State.get
   pure bound
 

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -140,7 +140,35 @@ unitTests = testGroup "Unit tests"
   , testCase "app with a lot of arguments" $ do
       res <- parseSuccessful (parseApplied >> scn >> eof) "app (\\x y z -> x) 0 1 2"
       res `compare` True @?= EQ
+  , testCase "testLetIndentation" $ do
+      res <- parseSuccessful (parseLet <* scn <* eof) testLetIndentation
+      res `compare` True @?= EQ
+  , testCase "testLetIncorrectIndentation1" $ do
+      res <- parseSuccessful (parseLet <* scn <* eof) testLetIncorrectIndentation1
+      res `compare` False @?= EQ
+  , testCase "testLetIncorrectIndentation2" $ do
+      res <- parseSuccessful (parseLet <* scn <* eof) testLetIncorrectIndentation2
+      res `compare` False @?= EQ
   ]
+
+testLetIndentation = unlines
+  [ "let x = 0"
+  , "    y = 1"
+  , "in x"
+  ]
+
+testLetIncorrectIndentation1 = unlines
+  [ "let x = 0"
+  , "  y = 1"
+  , "in x + y"
+  ]
+
+testLetIncorrectIndentation2 = unlines
+  [ "let x = 0"
+  , "      y = 1"
+  , "in x + y"
+  ]
+
 
 runTestPair :: String -> IO String
 runTestPair = runSILParser parsePair

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -612,7 +612,7 @@ fiveApp = concat
 
 nestedNamedFunctionsIssue = concat
   [ "main = let bindTest = \\tlb -> let f1 = \\f -> f tlb\n"
-  , "                                   f2 = \\f -> succ (f1 f)\n"
+  , "                                  f2 = \\f -> succ (f1 f)\n"
   , "                               in f2 succ\n"
   , "       in bindTest 0"
   ]

--- a/tictactoe.sil
+++ b/tictactoe.sil
@@ -1,9 +1,9 @@
-drawPiece
- = #piece alt -> if piece
-                    then if left piece
-                            then "O"
-                            else "X"
-                    else alt
+
+drawPiece = #piece alt -> if piece
+                             then if left piece
+                                     then "O"
+                                     else "X"
+                             else alt
 
 drawBoard
  = #pieces -> let getPiece = \n -> left (n (\x -> right x) pieces)
@@ -104,5 +104,6 @@ main
                                 then {nextPlayer,newBoard}
                                 else 0
              in {output, nextState}
+
 
 


### PR DESCRIPTION
Issue 12 (Fix whitespace/indent parsing) fixed:
- let only parses if bindings are in the same indentation level
- newline at the beginning of a file used to give a parse error. Now it doesnt.