### PR TITLE
updated README.md and improved github actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         # Only needed for private caches
         #authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    # This might be overkill: telomare cache could be enough.
     - run: cachix use iohk
     - run: nix-build -A telomare.components.library
     - run: nix-build -A telomare.components.tests
-    - run: nix-shell --run "echo OK"

--- a/README.md
+++ b/README.md
@@ -26,15 +26,21 @@ This project is in active development. Do expect bugs and general trouble, and p
    ```
    $ curl https://nixos.org/nix/install | sh
    ```
-3. Enter a Nix shell. This will setup an environment where all external dependencies will be available (such as `cabal` for building):
+3. Optional (reduces build time by using telomare's cache):
+   ```
+   # Install cachix with nix-env or adding `cachix` to your `/etc/nixos/configuration.nix`'s' `environment.systemPackages` if in NixOS.
+   $ nix-env -iA cachix -f https://cachix.org/api/v1/install
+   $ cachix use telomare
+   ```
+4. Enter a Nix shell. This will setup an environment where all external dependencies will be available (such as `cabal` for building):
    ```
    $ nix-shell shell.nix
    ```
-4. Build the project:
+5. Build the project:
    ```
    $ cabal new-build
    ```
-5. Run the tictactoe example and start playing with a friend:
+6. Run the tictactoe example and start playing with a friend:
    ```
    $ cabal new-run telomare-exe
    ```


### PR DESCRIPTION
README.md now contains instructions for cachix cache.

removed:     - run: nix-shell --run "echo OK" 

from `.github/workflow/test.yml`

because it could take up to 2 hrs to run.