### PR TITLE
updated github workflow versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,13 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.1
-    - uses: cachix/install-nix-action@v11
+    - uses: actions/checkout@v2.3.4
+    - uses: cachix/install-nix-action@v12
       # with:
       #   skip_adding_nixpkgs_channel: true
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - uses: cachix/cachix-action@v6
+    - uses: cachix/cachix-action@v8
       with:
         name: telomare
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
CI update because of https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/