### PR TITLE
Adding restrictions to haddock build trigger

### DIFF
--- a/.github/workflows/telomare-ci.yml
+++ b/.github/workflows/telomare-ci.yml
@@ -32,6 +32,7 @@ jobs:
         nix run .#telomare:test:telomare-parser-test
         nix run .#telomare:test:telomare-serializer-test
         echo ${{ github.ref }}
+        echo ${{ github.repository }}
 
   release:
     if: ${{ (github.ref == 'refs/heads/master') && (github.repository == 'Stand-In-Language/stand-in-language') }}

--- a/.github/workflows/telomare-ci.yml
+++ b/.github/workflows/telomare-ci.yml
@@ -34,7 +34,7 @@ jobs:
         echo ${{ github.ref }}
 
   release:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ (github.ref == 'refs/heads/master') && (github.repository == 'Stand-In-Language/stand-in-language') }}
     needs: tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Restriction added so that documentation only gets build when pushed to Stand-In-Language/stand-in-language and not on forks like hhefesto/stand-in-language