### PR TITLE
new syntax of UniqueUP

### DIFF
--- a/examples.tel
+++ b/examples.tel
@@ -4,12 +4,12 @@
 main = \input -> ("Hello, World!", 0)
 
 -- Simple example of ad-hoc user defined types
--- MyInt = let intTag = unique
---         in ( \i -> if not i
---                    then "MyInt must not be 0"
---                    else (intTag, i)
---            , \i -> if dEqual (left i) intTag
---                    then 0
---                    else "expecting MyInt"
---            )
+-- MyInt = let wrapper = \h -> ( \i -> if not i
+--                               	    then "MyInt must n"
+--                                     else  i
+--                             , \i -> if dEqual (left i)
+--                                     then 0
+--                                     else "expecting MyInt"
+--                             )
+--         in wrapper (# wrapper)
 -- main = \i -> ((left MyInt) 8, 0)

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -167,7 +167,6 @@ instance Arbitrary UnprocessedParsedTerm where
           , (IntUP <$> elements [0..9])
           , (ChurchUP <$> elements [0..9])
           , (pure UnsizedRecursionUP)
-          , (pure UniqueUP)
           ]
     lambdaTerms = ["w", "x", "y", "z"]
     letTerms = map (("l" <>) . show) [1..255]
@@ -189,6 +188,7 @@ instance Arbitrary UnprocessedParsedTerm where
                                  0 -> leaves varList
                                  x -> oneof
                                    [ leaves varList
+                                   , UniqueUP <$> recur (i - 1)
                                    , LeftUP <$> recur (i - 1)
                                    , RightUP <$> recur (i - 1)
                                    , TraceUP <$> recur (i - 1)
@@ -211,7 +211,6 @@ instance Arbitrary UnprocessedParsedTerm where
                                    , AppUP <$> recur half <*> recur half
                                    ]
   shrink = \case
-    UniqueUP -> []
     StringUP s -> case s of
       [] -> []
       _  -> pure . StringUP $ tail s
@@ -223,6 +222,7 @@ instance Arbitrary UnprocessedParsedTerm where
       x -> pure . ChurchUP $ x - 1
     UnsizedRecursionUP -> []
     VarUP _ -> []
+    UniqueUP x -> x : map UniqueUP (shrink x)
     LeftUP x -> x : map LeftUP (shrink x)
     RightUP x -> x : map RightUP (shrink x)
     TraceUP x -> x : map TraceUP (shrink x)


### PR DESCRIPTION
```haskell
let wrapper1 = \x -> x in (#wrapper1)
let wrapper2 = \x -> x in (#wrapper2)
```
should maybe give the same hash. There's a commented test for this but there is no solution yet.