### PR TITLE
documentation ci fixed

### DIFF
--- a/.github/workflows/telomare-ci.yml
+++ b/.github/workflows/telomare-ci.yml
@@ -97,7 +97,7 @@ jobs:
           ls
           rm -rf stand-in-language.github.io/docs/haddock/
           mkdir stand-in-language.github.io/docs/haddock/
-          cp -r telomare/dist-newstyle/build/x86_64-linux/ghc-8.10.7/telomare-0.1.0.0/doc/html/telomare/. stand-in-language.github.io/docs/haddock
+          cp -r telomare/dist-newstyle/build/x86_64-linux/ghc-9.2.2/telomare-0.1.0.0/doc/html/telomare/. stand-in-language.github.io/docs/haddock
       - uses: EndBug/add-and-commit@v7
         with:
           message: 'haddock documentation automatically updated'


### PR DESCRIPTION
documentation with new ghc changes places: from ghc-8.10.7 to ghc-9.2.2