### PR TITLE
Make stylish-haskell not align imports and apply

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,380 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Format module header
+  #
+  # Currently, this option is not configurable and will format all exports and
+  # module declarations to minimize diffs
+  #
+  # - module_header:
+  #     # How many spaces use for indentation in the module header.
+  #     indent: 4
+  #
+  #     # Should export lists be sorted?  Sorting is only performed within the
+  #     # export section, as delineated by Haddock comments.
+  #     sort: true
+  #
+  #     # See `separate_lists` for the `imports` step.
+  #     separate_lists: true
+  #
+  #     # When to break the "where".
+  #     # Possible values:
+  #     # - exports: only break when there is an explicit export list.
+  #     # - single: only break when the export list counts more than one export.
+  #     # - inline: only break when the export list is too long. This is
+  #     #   determined by the `columns` setting. Not applicable when the export
+  #     #   list contains comments as newlines will be required.
+  #     # - always: always break before the "where".
+  #     break_where: exports
+  #
+  #     # Where to put open bracket
+  #     # Possible values:
+  #     # - same_line: put open bracket on the same line as the module name, before the
+  #     #              comment of the module
+  #     # - next_line: put open bracket on the next line, after module comment
+  #     open_bracket: next_line
+
+  # Format record definitions. This is disabled by default.
+  #
+  # You can control the layout of record fields. The only rules that can't be configured
+  # are these:
+  #
+  # - "|" is always aligned with "="
+  # - "," in fields is always aligned with "{"
+  # - "}" is likewise always aligned with "{"
+  #
+  # - records:
+  #     # How to format equals sign between type constructor and data constructor.
+  #     # Possible values:
+  #     # - "same_line" -- leave "=" AND data constructor on the same line as the type constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the next line.
+  #     equals: "indent 2"
+  #
+  #     # How to format first field of each record constructor.
+  #     # Possible values:
+  #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     first_field: "indent 2"
+  #
+  #     # How many spaces to insert between the column with "," and the beginning of the comment in the next line.
+  #     field_comment: 2
+  #
+  #     # How many spaces to insert before "deriving" clause. Deriving clauses are always on separate lines.
+  #     deriving: 2
+  #
+  #     # How many spaces to insert before "via" clause counted from indentation of deriving clause
+  #     # Possible values:
+  #     # - "same_line" -- "via" part goes on the same line as "deriving" keyword.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of "deriving" keyword.
+  #     via: "indent 2"
+  #
+  #     # Sort typeclass names in the "deriving" list alphabetically.
+  #     sort_deriving: true
+  #
+  #     # Whether or not to break enums onto several lines
+  #     #
+  #     # Default: false
+  #     break_enums: false
+  #
+  #     # Whether or not to break single constructor data types before `=` sign
+  #     #
+  #     # Default: true
+  #     break_single_constructors: true
+  #
+  #     # Whether or not to curry constraints on function.
+  #     #
+  #     # E.g: @allValues :: Enum a => Bounded a => Proxy a -> [a]@
+  #     #
+  #     # Instead of @allValues :: (Enum a, Bounded a) => Proxy a -> [a]@
+  #     #
+  #     # Default: false
+  #     curried_context: false
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  # Possible values:
+  # - always - Always align statements.
+  # - adjacent - Align statements that are on adjacent lines in groups.
+  # - never - Never align statements.
+  # All default to always.
+  - simple_align:
+      cases: always
+      top_level_patterns: always
+      records: always
+      multi_way_if: always
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: none
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - with_module_name: Import list is aligned `list_padding` spaces after
+      #   the module name.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #                          init, last, length)
+      #
+      #   This is mainly intended for use with `pad_module_names: false`.
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, head,
+      #                          init, last, length, scanl, scanr, take, drop,
+      #                          sort, nub)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # - repeat: Repeat the module name to align the import list.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head)
+      #   > import qualified Data.List      as List (init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      #
+      # Default: 4
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+      # Post qualify option moves any qualifies found in import declarations
+      # to the end of the declaration. This also adjust padding for any
+      # unqualified import declarations.
+      #
+      # - true: Qualified as <module name> is moved to the end of the
+      #   declaration.
+      #
+      #   > import Data.Bar
+      #   > import Data.Foo qualified as F
+      #
+      # - false: Qualified remains in the default location and unqualified
+      #   imports are padded to align with qualified imports.
+      #
+      #   > import           Data.Bar
+      #   > import qualified Data.Foo as F
+      #
+      # Default: false
+      post_qualify: false
+
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-# LANGUAGE #-}'.
+      #
+      # - vertical_compact: Similar to vertical, but use only one language pragma.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+      # Language prefix to be used for pragma declaration, this allows you to
+      # use other options non case-sensitive like "language" or "Language".
+      # If a non correct String is provided, it will default to: LANGUAGE.
+      language_prefix: LANGUAGE
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account.
+#
+# Set this to null to disable all line wrapping.
+#
+# Default: 80.
+columns: 80
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes
+
+# Attempt to find the cabal file in ancestors of the current directory, and
+# parse options (currently only language extensions) from that.
+#
+# Default: true
+cabal: true

--- a/bench/MemoryBench.hs
+++ b/bench/MemoryBench.hs
@@ -4,33 +4,32 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main where
 
-import           Control.Applicative
-import           Control.DeepSeq
-import           Control.Exception
-import           Control.Monad
-import           Data.Char
-import           Data.Either
-import           GHC.Generics         (Generic)
-import           System.IO            (hPutStrLn, stderr)
+import Control.Applicative
+import Control.DeepSeq
+import Control.Exception
+import Control.Monad
+import Data.Char
+import Data.Either
+import GHC.Generics (Generic)
+import System.IO (hPutStrLn, stderr)
 
-import qualified System.IO.Strict     as Strict
-import           Telomare
-import           Telomare.Eval
-import           Telomare.Optimizer
-import           Telomare.Parser
-import           Telomare.RunTime
-import           Telomare.TypeChecker (TypeCheckError (..), inferType,
-                                       typeCheck)
+import qualified System.IO.Strict as Strict
+import Telomare
+import Telomare.Eval
+import Telomare.Optimizer
+import Telomare.Parser
+import Telomare.RunTime
+import Telomare.TypeChecker (TypeCheckError (..), inferType, typeCheck)
 
-import           MemoryBench.Cases
-import           MemoryBench.LLVM
-import           Paths_telomare
+import MemoryBench.Cases
+import MemoryBench.LLVM
+import Paths_telomare
 
-import           Text.Parsec.Error    (ParseError)
-import qualified Weigh                as Weigh
-import           Weigh                hiding (Case, Max)
+import Text.Parsec.Error (ParseError)
+import qualified Weigh as Weigh
+import Weigh hiding (Case, Max)
 
-import           Debug.Trace
+import Debug.Trace
 
 foreign import capi "gc.h GC_INIT" gcInit :: IO ()
 foreign import ccall "gc.h GC_allow_register_threads" gcAllowRegisterThreads :: IO ()

--- a/bench/MemoryBench/Cases.hs
+++ b/bench/MemoryBench/Cases.hs
@@ -8,12 +8,12 @@
 
 module MemoryBench.Cases where
 
-import           Text.Parsec      hiding (label)
-import           Text.Parsec.Char
+import Text.Parsec hiding (label)
+import Text.Parsec.Char
 
 import qualified System.IO.Strict as Strict
 
-import           Data.Maybe
+import Data.Maybe
 
 type Label    = String
 

--- a/bench/MemoryBench/LLVM.hs
+++ b/bench/MemoryBench/LLVM.hs
@@ -3,76 +3,76 @@
 {-# LANGUAGE TupleSections       #-}
 module MemoryBench.LLVM where
 
-import           LLVM.AST                              hiding (Module)
-import qualified LLVM.AST                              as AST
-import           LLVM.AST.AddrSpace
-import           LLVM.AST.CallingConvention
-import           LLVM.AST.Constant
-import           LLVM.AST.DataLayout
-import           LLVM.AST.DLL
-import           LLVM.AST.Float
-import           LLVM.AST.FloatingPointPredicate       hiding (True)
-import           LLVM.AST.InlineAssembly
-import           LLVM.AST.IntegerPredicate
-import           LLVM.AST.Linkage
-import           LLVM.AST.ParameterAttribute
-import           LLVM.AST.RMWOperation
-import           LLVM.AST.ThreadLocalStorage
-import           LLVM.AST.Type                         hiding (void)
-import           LLVM.AST.Visibility
-import           LLVM.Context
-import           LLVM.Module                           hiding (Module)
+import LLVM.AST hiding (Module)
+import qualified LLVM.AST as AST
+import LLVM.AST.AddrSpace
+import LLVM.AST.CallingConvention
+import LLVM.AST.Constant
+import LLVM.AST.DataLayout
+import LLVM.AST.DLL
+import LLVM.AST.Float
+import LLVM.AST.FloatingPointPredicate hiding (True)
+import LLVM.AST.InlineAssembly
+import LLVM.AST.IntegerPredicate
+import LLVM.AST.Linkage
+import LLVM.AST.ParameterAttribute
+import LLVM.AST.RMWOperation
+import LLVM.AST.ThreadLocalStorage
+import LLVM.AST.Type hiding (void)
+import LLVM.AST.Visibility
+import LLVM.Context
+import LLVM.Module hiding (Module)
 
-import           LLVM.AST.COMDAT
-import           LLVM.AST.FunctionAttribute
-import           LLVM.AST.Operand                      hiding (Module)
-import qualified LLVM.AST.Operand                      as AST
+import LLVM.AST.COMDAT
+import LLVM.AST.FunctionAttribute
+import LLVM.AST.Operand hiding (Module)
+import qualified LLVM.AST.Operand as AST
 
 import qualified LLVM.Internal.FFI.OrcJIT.CompileLayer as OJ.I
-import qualified LLVM.Internal.OrcJIT.IRCompileLayer   as OJ.I
-import qualified LLVM.Internal.OrcJIT.LinkingLayer     as OJ.I
-import qualified LLVM.Linking                          as Linking
-import qualified LLVM.OrcJIT                           as OJ
-import qualified LLVM.OrcJIT.CompileLayer              as OJ
+import qualified LLVM.Internal.OrcJIT.IRCompileLayer as OJ.I
+import qualified LLVM.Internal.OrcJIT.LinkingLayer as OJ.I
+import qualified LLVM.Linking as Linking
+import qualified LLVM.OrcJIT as OJ
+import qualified LLVM.OrcJIT.CompileLayer as OJ
 
-import qualified LLVM.CodeGenOpt                       as CodeGenOpt
-import qualified LLVM.CodeModel                        as CodeModel
+import qualified LLVM.CodeGenOpt as CodeGenOpt
+import qualified LLVM.CodeModel as CodeModel
 
-import           LLVM.Internal.Attribute
-import           LLVM.Internal.Coding
-import           LLVM.Internal.Context
-import           LLVM.Internal.EncodeAST
-import           LLVM.Internal.Function
-import           LLVM.Internal.Global
-import           LLVM.Internal.Module
-import           LLVM.Internal.Type
+import LLVM.Internal.Attribute
+import LLVM.Internal.Coding
+import LLVM.Internal.Context
+import LLVM.Internal.EncodeAST
+import LLVM.Internal.Function
+import LLVM.Internal.Global
+import LLVM.Internal.Module
+import LLVM.Internal.Type
 
-import qualified LLVM.Internal.Target                  as Target
-import qualified LLVM.Relocation                       as Reloc
-import qualified LLVM.Target                           as Target
+import qualified LLVM.Internal.Target as Target
+import qualified LLVM.Relocation as Reloc
+import qualified LLVM.Target as Target
 
-import qualified LLVM.AST                              as A
-import qualified LLVM.AST.AddrSpace                    as A
-import qualified LLVM.AST.DataLayout                   as A
-import qualified LLVM.AST.Global                       as A.G
+import qualified LLVM.AST as A
+import qualified LLVM.AST.AddrSpace as A
+import qualified LLVM.AST.DataLayout as A
+import qualified LLVM.AST.Global as A.G
 
-import           Control.DeepSeq
-import           Control.Exception
-import           Control.Monad
-import           Control.Monad.IO.Class
-import           Control.Monad.State.Class
-import qualified Data.ByteString                       as B
-import           Data.Foldable
-import qualified Data.Map                              as Map
-import           Debug.Trace
-import           Foreign.C.String
-import           Foreign.Ptr
+import Control.DeepSeq
+import Control.Exception
+import Control.Monad
+import Control.Monad.IO.Class
+import Control.Monad.State.Class
+import qualified Data.ByteString as B
+import Data.Foldable
+import qualified Data.Map as Map
+import Debug.Trace
+import Foreign.C.String
+import Foreign.Ptr
 
-import           Naturals
-import           Telomare
-import qualified Telomare.Llvm                         as LLVM
+import Naturals
+import Telomare
+import qualified Telomare.Llvm as LLVM
 
-import           Weigh
+import Weigh
 
 
 instance NFData DataLayout

--- a/bench/SerializerBench.hs
+++ b/bench/SerializerBench.hs
@@ -1,30 +1,30 @@
 {-# LANGUAGE StandaloneDeriving #-}
 module Main where
 
-import           Control.DeepSeq
-import           Data.Char
-import qualified Data.Vector.Storable  as S
+import Control.DeepSeq
+import Data.Char
+import qualified Data.Vector.Storable as S
 
-import           Foreign.Marshal.Alloc
-
-
-import           Criterion.Main
-import           Criterion.Measurement
-import           Criterion.Types
+import Foreign.Marshal.Alloc
 
 
-import           Telomare
+import Criterion.Main
+import Criterion.Measurement
+import Criterion.Types
+
+
+import Telomare
 --import Telomare.Llvm
-import qualified System.IO.Strict      as Strict
-import           Telomare.Eval
-import           Telomare.Optimizer
-import           Telomare.Parser
-import           Telomare.RunTime
-import           Telomare.Serializer
-import           Telomare.Serializer.C
-import           Telomare.TypeChecker  (inferType, typeCheck)
+import qualified System.IO.Strict as Strict
+import Telomare.Eval
+import Telomare.Optimizer
+import Telomare.Parser
+import Telomare.RunTime
+import Telomare.Serializer
+import Telomare.Serializer.C
+import Telomare.TypeChecker (inferType, typeCheck)
 
-import           System.Mem
+import System.Mem
 
 performTests :: IExpr -> IO ()
 performTests iexpr = do

--- a/src/Naturals.hs
+++ b/src/Naturals.hs
@@ -6,27 +6,26 @@
 -- {-# LANGUAGE EmptyDataDecls #-}
 module Naturals where
 
-import           Control.Applicative
-import           Control.DeepSeq
-import           Control.Monad.Fix
-import           Control.Monad.Identity
-import           Control.Monad.State.Lazy
-import           Data.Binary
-import           Data.Functor
-import           Data.Int                 (Int64)
-import           Data.Map                 (Map)
-import           Data.Monoid
-import           Data.Set                 (Set)
-import           Debug.Trace
-import           GHC.Generics
+import Control.Applicative
+import Control.DeepSeq
+import Control.Monad.Fix
+import Control.Monad.Identity
+import Control.Monad.State.Lazy
+import Data.Binary
+import Data.Functor
+import Data.Int (Int64)
+import Data.Map (Map)
+import Data.Monoid
+import Data.Set (Set)
+import Debug.Trace
+import GHC.Generics
 
 import qualified Control.Monad.State.Lazy as State
-import qualified Data.Map                 as Map
-import qualified Data.Set                 as Set
+import qualified Data.Map as Map
+import qualified Data.Set as Set
 
-import           Telomare                 (FragExpr (..), FragIndex (..),
-                                           IExpr (..), pattern App,
-                                           pattern ChurchNum, pattern ToChurch)
+import Telomare (FragExpr (..), FragIndex (..), IExpr (..), pattern App,
+                 pattern ChurchNum, pattern ToChurch)
 
 debug :: Bool
 debug = True

--- a/src/PrettyPrint.hs
+++ b/src/PrettyPrint.hs
@@ -2,11 +2,11 @@
 
 module PrettyPrint where
 
-import           Data.Map (Map)
-import           Naturals (NExpr (..), NExprs (..), NResult)
-import           Telomare (FragExpr (..), FragExprUR (..), FragIndex (..),
-                           IExpr (..), PartialType (..), PrettyPartialType (..),
-                           RecursionSimulationPieces (..), Term3 (..), rootFrag)
+import Data.Map (Map)
+import Naturals (NExpr (..), NExprs (..), NResult)
+import Telomare (FragExpr (..), FragExprUR (..), FragIndex (..), IExpr (..),
+                 PartialType (..), PrettyPartialType (..),
+                 RecursionSimulationPieces (..), Term3 (..), rootFrag)
 
 import qualified Data.Map as Map
 

--- a/src/Telomare.hs
+++ b/src/Telomare.hs
@@ -14,22 +14,22 @@
 module Telomare where --(IExpr(..), ParserTerm(..), LamType(..), Term1(..), Term2(..), Term3(..), Term4(..)
                --, FragExpr(..), FragIndex, TelomareLike, fromTelomare, toTelomare, rootFrag) where
 
-import           Control.Applicative
-import           Control.DeepSeq
-import           Control.Lens.Combinators
-import           Control.Lens.Plated
-import           Control.Monad.Except
-import           Control.Monad.State      (State)
-import qualified Control.Monad.State      as State
-import           Data.Char
-import           Data.Functor.Classes
-import           Data.Functor.Foldable
-import           Data.Functor.Foldable.TH
-import           Data.Map                 (Map)
-import qualified Data.Map                 as Map
-import qualified Data.Set                 as Set
-import           Data.Void
-import           GHC.Generics
+import Control.Applicative
+import Control.DeepSeq
+import Control.Lens.Combinators
+import Control.Lens.Plated
+import Control.Monad.Except
+import Control.Monad.State (State)
+import qualified Control.Monad.State as State
+import Data.Char
+import Data.Functor.Classes
+import Data.Functor.Foldable
+import Data.Functor.Foldable.TH
+import Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Data.Void
+import GHC.Generics
 
 {- top level TODO list
  - change AbortFrag form to something more convenient

--- a/src/Telomare/Decompiler.hs
+++ b/src/Telomare/Decompiler.hs
@@ -2,17 +2,15 @@
 
 module Telomare.Decompiler where
 
-import           Control.Monad       (foldM, liftM2)
+import Control.Monad (foldM, liftM2)
 import qualified Control.Monad.State as State
-import           Data.List           (intercalate)
-import qualified Data.Map            as Map
-import           Data.Semigroup      (Max (..))
-import           Telomare            (FragExpr (..), FragIndex (FragIndex),
-                                      IExpr (..), LamType (..), ParserTerm (..),
-                                      Term1, Term2, Term3 (Term3),
-                                      Term4 (Term4), buildFragMap, deferF,
-                                      rootFrag, unFragExprUR)
-import           Telomare.Parser     (UnprocessedParsedTerm (..))
+import Data.List (intercalate)
+import qualified Data.Map as Map
+import Data.Semigroup (Max (..))
+import Telomare (FragExpr (..), FragIndex (FragIndex), IExpr (..), LamType (..),
+                 ParserTerm (..), Term1, Term2, Term3 (Term3), Term4 (Term4),
+                 buildFragMap, deferF, rootFrag, unFragExprUR)
+import Telomare.Parser (UnprocessedParsedTerm (..))
 
 decompileUPT :: UnprocessedParsedTerm -> String
 decompileUPT =

--- a/src/Telomare/Eval.hs
+++ b/src/Telomare/Eval.hs
@@ -3,45 +3,37 @@
 {-# LANGUAGE TupleSections   #-}
 module Telomare.Eval where
 
-import           Control.Lens.Plated
-import           Control.Monad.Except
-import           Control.Monad.Reader      (Reader, runReader)
-import           Control.Monad.State       (StateT)
-import qualified Control.Monad.State       as State
-import           Control.Monad.Trans.Accum (AccumT)
+import Control.Lens.Plated
+import Control.Monad.Except
+import Control.Monad.Reader (Reader, runReader)
+import Control.Monad.State (StateT)
+import qualified Control.Monad.State as State
+import Control.Monad.Trans.Accum (AccumT)
 import qualified Control.Monad.Trans.Accum as Accum
-import           Data.DList                (DList)
-import           Data.Functor.Foldable     (cata, embed, project)
-import           Data.Map                  (Map)
-import qualified Data.Map                  as Map
-import           Data.Set                  (Set)
-import qualified Data.Set                  as Set
-import           Data.Void
-import           Debug.Trace
+import Data.DList (DList)
+import Data.Functor.Foldable (cata, embed, project)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Void
+import Debug.Trace
 
-import           System.IO
-import           System.Process
+import System.IO
+import System.Process
 
-import           Telomare                  (BreakState, BreakState', ExprA (..),
-                                            FragExpr (..),
-                                            FragIndex (FragIndex), IExpr (..),
-                                            PartialType (..),
-                                            RecursionPieceFrag,
-                                            RecursionSimulationPieces (..),
-                                            RunTimeError (..),
-                                            TelomareLike (..), Term3 (Term3),
-                                            Term4 (Term4),
-                                            UnsizedRecursionToken (..), app,
-                                            g2s, innerChurchF, insertAndGetKey,
-                                            pattern AbortAny,
-                                            pattern AbortRecursion,
-                                            pattern AbortUser, rootFrag, s2g,
-                                            unFragExprUR)
-import           Telomare.Optimizer        (optimize)
-import           Telomare.Possible         (evalA)
-import           Telomare.RunTime          (hvmEval, optimizedEval, pureEval,
-                                            simpleEval)
-import           Telomare.TypeChecker      (TypeCheckError (..), typeCheck)
+import Telomare (BreakState, BreakState', ExprA (..), FragExpr (..),
+                 FragIndex (FragIndex), IExpr (..), PartialType (..),
+                 RecursionPieceFrag, RecursionSimulationPieces (..),
+                 RunTimeError (..), TelomareLike (..), Term3 (Term3),
+                 Term4 (Term4), UnsizedRecursionToken (..), app, g2s,
+                 innerChurchF, insertAndGetKey, pattern AbortAny,
+                 pattern AbortRecursion, pattern AbortUser, rootFrag, s2g,
+                 unFragExprUR)
+import Telomare.Optimizer (optimize)
+import Telomare.Possible (evalA)
+import Telomare.RunTime (hvmEval, optimizedEval, pureEval, simpleEval)
+import Telomare.TypeChecker (TypeCheckError (..), typeCheck)
 
 data ExpP = ZeroP
     | PairP ExpP ExpP

--- a/src/Telomare/Llvm.hs
+++ b/src/Telomare/Llvm.hs
@@ -4,57 +4,55 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Telomare.Llvm where
 
-import           Control.Monad.Except
-import           Control.Monad.State.Strict
-import           Crypto.Hash                 (Digest, SHA256, hashlazy)
-import           Data.Binary                 (encode)
-import qualified Data.ByteArray              as BA (unpack)
-import           Data.ByteString             (ByteString)
-import qualified Data.ByteString             as BS
-import qualified Data.ByteString.Base16      as Base16
-import qualified Data.ByteString.Char8       as BSC
-import qualified Data.ByteString.Lazy        as BSL
-import           Data.ByteString.Short       (toShort)
-import           Data.Int                    (Int64)
-import           Data.Map.Strict             (Map)
-import qualified Data.Map.Strict             as Map
-import           Data.String                 (fromString)
-import           Foreign.Ptr                 (FunPtr, IntPtr (..), Ptr,
-                                              WordPtr (..), castPtrToFunPtr,
-                                              intPtrToPtr, plusPtr,
-                                              wordPtrToPtr)
-import           Foreign.Storable            (peek)
-import           System.Clock
-import           System.IO                   (hPutStrLn, stderr)
-import           Text.Printf
+import Control.Monad.Except
+import Control.Monad.State.Strict
+import Crypto.Hash (Digest, SHA256, hashlazy)
+import Data.Binary (encode)
+import qualified Data.ByteArray as BA (unpack)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Short (toShort)
+import Data.Int (Int64)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.String (fromString)
+import Foreign.Ptr (FunPtr, IntPtr (..), Ptr, WordPtr (..), castPtrToFunPtr,
+                    intPtrToPtr, plusPtr, wordPtrToPtr)
+import Foreign.Storable (peek)
+import System.Clock
+import System.IO (hPutStrLn, stderr)
+import Text.Printf
 
-import           LLVM.AST                    hiding (Monotonic)
-import           LLVM.AST.Global             as G
-import           LLVM.Context
-import           LLVM.IRBuilder.Constant     (int64)
-import           LLVM.IRBuilder.Module
-import           LLVM.IRBuilder.Monad
-import           LLVM.Module                 as Mod
-import           LLVM.PassManager
+import LLVM.AST hiding (Monotonic)
+import LLVM.AST.Global as G
+import LLVM.Context
+import LLVM.IRBuilder.Constant (int64)
+import LLVM.IRBuilder.Module
+import LLVM.IRBuilder.Monad
+import LLVM.Module as Mod
+import LLVM.PassManager
 
-import qualified LLVM.AST                    as AST
-import qualified LLVM.AST.AddrSpace          as AddrSpace
-import qualified LLVM.AST.Constant           as C
-import qualified LLVM.AST.IntegerPredicate   as IP
+import qualified LLVM.AST as AST
+import qualified LLVM.AST.AddrSpace as AddrSpace
+import qualified LLVM.AST.Constant as C
+import qualified LLVM.AST.IntegerPredicate as IP
 import qualified LLVM.AST.ParameterAttribute as PA
-import qualified LLVM.AST.Type               as T
-import qualified LLVM.CodeGenOpt             as CodeGenOpt
-import qualified LLVM.CodeModel              as CodeModel
-import qualified LLVM.IRBuilder.Instruction  as IRI
-import qualified LLVM.IRBuilder.Module       as IRM
-import qualified LLVM.Linking                as Linking
-import qualified LLVM.OrcJIT                 as OJ
-import qualified LLVM.OrcJIT.CompileLayer    as OJ
-import qualified LLVM.Relocation             as Reloc
-import qualified LLVM.Target                 as Target
+import qualified LLVM.AST.Type as T
+import qualified LLVM.CodeGenOpt as CodeGenOpt
+import qualified LLVM.CodeModel as CodeModel
+import qualified LLVM.IRBuilder.Instruction as IRI
+import qualified LLVM.IRBuilder.Module as IRM
+import qualified LLVM.Linking as Linking
+import qualified LLVM.OrcJIT as OJ
+import qualified LLVM.OrcJIT.CompileLayer as OJ
+import qualified LLVM.Relocation as Reloc
+import qualified LLVM.Target as Target
 
-import           Naturals
-import           Telomare                    (FragIndex)
+import Naturals
+import Telomare (FragIndex)
 
 foreign import ccall "dynamic" haskFun :: FunPtr (IO (Ptr Int64)) -> IO (Ptr Int64)
 

--- a/src/Telomare/Optimizer.hs
+++ b/src/Telomare/Optimizer.hs
@@ -1,12 +1,12 @@
 module Telomare.Optimizer where
 
-import           Control.Lens.Plated (transform)
-import           Data.Map            (Map)
-import qualified Data.Map            as Map
-import           Data.Set            (Set)
-import qualified Data.Set            as Set
+import Control.Lens.Plated (transform)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
 
-import           Telomare            (IExpr (..))
+import Telomare (IExpr (..))
 
 -- TODO think about how removing var indexing will make it hard to figure out closure arity
 -- oh wait, closures will all take one argument and return one argument, and closure

--- a/src/Telomare/Parser.hs
+++ b/src/Telomare/Parser.hs
@@ -7,52 +7,47 @@
 
 module Telomare.Parser where
 
-import           Codec.Binary.UTF8.String   (encode)
-import           Control.Lens.Combinators
-import           Control.Lens.Operators
-import           Control.Lens.Plated
-import           Control.Monad
-import           Control.Monad.State        (State)
-import qualified Control.Monad.State        as State
-import           Crypto.Hash                (Digest, SHA256, hash)
-import           Data.Bifunctor
-import qualified Data.ByteArray             as BA
-import           Data.ByteString            (ByteString)
-import qualified Data.ByteString            as BS
-import           Data.Char
-import qualified Data.Foldable              as F
-import           Data.Functor               (($>))
-import           Data.Functor.Foldable
-import           Data.Functor.Foldable.TH
-import           Data.List                  (delete, elem, elemIndex)
-import           Data.Map                   (Map, fromList, toList)
-import qualified Data.Map                   as Map
-import           Data.Maybe                 (fromJust)
-import           Data.Set                   (Set, (\\))
-import qualified Data.Set                   as Set
-import           Data.Void
-import           Data.Word                  (Word8)
-import           Debug.Trace
-import qualified System.IO.Strict           as Strict
-import           Text.Megaparsec            hiding (State)
-import           Text.Megaparsec.Char
+import Codec.Binary.UTF8.String (encode)
+import Control.Lens.Combinators
+import Control.Lens.Operators
+import Control.Lens.Plated
+import Control.Monad
+import Control.Monad.State (State)
+import qualified Control.Monad.State as State
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.Bifunctor
+import qualified Data.ByteArray as BA
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Char
+import qualified Data.Foldable as F
+import Data.Functor (($>))
+import Data.Functor.Foldable
+import Data.Functor.Foldable.TH
+import Data.List (delete, elem, elemIndex)
+import Data.Map (Map, fromList, toList)
+import qualified Data.Map as Map
+import Data.Maybe (fromJust)
+import Data.Set (Set, (\\))
+import qualified Data.Set as Set
+import Data.Void
+import Data.Word (Word8)
+import Debug.Trace
+import qualified System.IO.Strict as Strict
+import Text.Megaparsec hiding (State)
+import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
-import           Text.Megaparsec.Debug
-import           Text.Megaparsec.Pos
-import           Text.Read                  (readMaybe)
+import Text.Megaparsec.Debug
+import Text.Megaparsec.Pos
+import Text.Read (readMaybe)
 
 
-import           Telomare                   (BreakState', FragExpr (..),
-                                             FragExprUR (..), FragIndex (..),
-                                             IExpr (..), LamType (..),
-                                             ParserTerm (..), ParserTermF (..),
-                                             RecursionPieceFrag,
-                                             RecursionSimulationPieces (..),
-                                             Term1 (..), Term2 (..), Term3 (..),
-                                             UnsizedRecursionToken, appF, clamF,
-                                             deferF, lamF, nextBreakToken,
-                                             unsizedRecursionWrapper, varNF)
-import           Telomare.TypeChecker       (typeCheck)
+import Telomare (BreakState', FragExpr (..), FragExprUR (..), FragIndex (..),
+                 IExpr (..), LamType (..), ParserTerm (..), ParserTermF (..),
+                 RecursionPieceFrag, RecursionSimulationPieces (..), Term1 (..),
+                 Term2 (..), Term3 (..), UnsizedRecursionToken, appF, clamF,
+                 deferF, lamF, nextBreakToken, unsizedRecursionWrapper, varNF)
+import Telomare.TypeChecker (typeCheck)
 
 data UnprocessedParsedTerm
   = VarUP String

--- a/src/Telomare/Possible.hs
+++ b/src/Telomare/Possible.hs
@@ -8,32 +8,30 @@
 {-# LANGUAGE TypeFamilies        #-}
 module Telomare.Possible where
 
-import           Control.Applicative
-import           Control.Lens.Plated
-import           Control.Monad
-import           Control.Monad.Reader      (Reader, ReaderT)
-import qualified Control.Monad.Reader      as Reader
-import           Control.Monad.State       (State, StateT)
-import qualified Control.Monad.State       as State
-import           Control.Monad.Trans.Class
-import           Data.DList                (DList)
-import qualified Data.DList                as DList
-import           Data.Foldable
-import           Data.Functor.Classes
-import           Data.Functor.Foldable
-import           Data.Functor.Foldable.TH
-import           Data.Map                  (Map)
-import qualified Data.Map                  as Map
-import           Data.Monoid
-import           Data.Set                  (Set)
-import qualified Data.Set                  as Set
-import           Data.Void
-import           Debug.Trace
-import           Telomare                  (FragExpr (..), FragIndex,
-                                            IExpr (..),
-                                            TelomareLike (fromTelomare, toTelomare),
-                                            Term4 (..), pattern AbortAny,
-                                            rootFrag)
+import Control.Applicative
+import Control.Lens.Plated
+import Control.Monad
+import Control.Monad.Reader (Reader, ReaderT)
+import qualified Control.Monad.Reader as Reader
+import Control.Monad.State (State, StateT)
+import qualified Control.Monad.State as State
+import Control.Monad.Trans.Class
+import Data.DList (DList)
+import qualified Data.DList as DList
+import Data.Foldable
+import Data.Functor.Classes
+import Data.Functor.Foldable
+import Data.Functor.Foldable.TH
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Monoid
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Void
+import Debug.Trace
+import Telomare (FragExpr (..), FragIndex, IExpr (..),
+                 TelomareLike (fromTelomare, toTelomare), Term4 (..),
+                 pattern AbortAny, rootFrag)
 
 
 -- foldr :: Foldable t => (a -> b -> b) -> b -> t a -> b

--- a/src/Telomare/RunTime.hs
+++ b/src/Telomare/RunTime.hs
@@ -4,27 +4,25 @@
 
 module Telomare.RunTime where
 
-import           Control.Exception
-import           Control.Monad.Except
-import           Control.Monad.Fix
-import           Data.Foldable
-import           Data.Functor.Foldable hiding (fold)
-import           Data.Functor.Identity
-import qualified Data.Map              as Map
-import           Data.Set              (Set)
-import qualified Data.Set              as Set
-import           Debug.Trace
-import           GHC.Exts              (fromList)
-import           Naturals              hiding (debug, debugTrace)
-import           PrettyPrint
-import           System.IO
-import           System.Process
-import           Telomare              (AbstractRunTime (eval), DataType (..),
-                                        FragIndex (FragIndex), IExpr (..),
-                                        IExprF (..), PrettyIExpr (PrettyIExpr),
-                                        RunResult, RunTimeError (..),
-                                        TelomareLike (fromTelomare, toTelomare))
-import           Text.Read             (readMaybe)
+import Control.Exception
+import Control.Monad.Except
+import Control.Monad.Fix
+import Data.Foldable
+import Data.Functor.Foldable hiding (fold)
+import Data.Functor.Identity
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Debug.Trace
+import GHC.Exts (fromList)
+import Naturals hiding (debug, debugTrace)
+import PrettyPrint
+import System.IO
+import System.Process
+import Telomare (AbstractRunTime (eval), DataType (..), FragIndex (FragIndex),
+                 IExpr (..), IExprF (..), PrettyIExpr (PrettyIExpr), RunResult,
+                 RunTimeError (..), TelomareLike (fromTelomare, toTelomare))
+import Text.Read (readMaybe)
 
 debug :: Bool
 debug = False

--- a/src/Telomare/Serializer.hs
+++ b/src/Telomare/Serializer.hs
@@ -4,14 +4,14 @@ module Telomare.Serializer (
   , unsafeDeserialize
 ) where
 
-import           Data.Word
+import Data.Word
 
-import           Data.Vector.Storable         (Vector, fromList, (!))
-import qualified Data.Vector.Storable         as S
+import Data.Vector.Storable (Vector, fromList, (!))
+import qualified Data.Vector.Storable as S
 import qualified Data.Vector.Storable.Mutable as SM
 
-import           Telomare                     (IExpr (..))
-import           Telomare.Serializer.C
+import Telomare (IExpr (..))
+import Telomare.Serializer.C
 
 
 serialize :: IExpr -> Vector Word8

--- a/src/Telomare/Serializer/C.hs
+++ b/src/Telomare/Serializer/C.hs
@@ -41,20 +41,20 @@ module Telomare.Serializer.C (
     , telomare_free
 ) where
 
-import           Telomare                 (IExpr (..))
+import Telomare (IExpr (..))
 
-import           Data.Vector.Storable     (Vector, fromList, (!))
-import qualified Data.Vector.Storable     as S
-import           Data.Word
+import Data.Vector.Storable (Vector, fromList, (!))
+import qualified Data.Vector.Storable as S
+import Data.Word
 
-import           Foreign.C.Types
-import           Foreign.ForeignPtr
-import           Foreign.Marshal.Alloc
-import           Foreign.Marshal.Array
-import           Foreign.Ptr
-import           Foreign.Storable.Generic
+import Foreign.C.Types
+import Foreign.ForeignPtr
+import Foreign.Marshal.Alloc
+import Foreign.Marshal.Array
+import Foreign.Ptr
+import Foreign.Storable.Generic
 
-import           GHC.Generics             (Generic)
+import GHC.Generics (Generic)
 
 -- | Type alias for expression tag for C
 type CTypeId = CUChar

--- a/src/Telomare/TypeChecker.hs
+++ b/src/Telomare/TypeChecker.hs
@@ -3,23 +3,21 @@
 
 module Telomare.TypeChecker where
 
-import           Control.Applicative
-import           Control.Lens.Plated  (transform)
-import           Control.Monad.Except
-import           Control.Monad.State  (State)
-import qualified Control.Monad.State  as State
-import qualified Data.DList           as DList
-import           Data.Map             (Map)
-import qualified Data.Map             as Map
-import           Data.Set             (Set)
-import qualified Data.Set             as Set
-import           Debug.Trace
-import           PrettyPrint
-import           Telomare             (FragExpr (..), FragExprUR (..),
-                                       FragIndex (..), PartialType (..),
-                                       PrettyPartialType (PrettyPartialType),
-                                       RecursionSimulationPieces (..),
-                                       Term3 (..), rootFrag)
+import Control.Applicative
+import Control.Lens.Plated (transform)
+import Control.Monad.Except
+import Control.Monad.State (State)
+import qualified Control.Monad.State as State
+import qualified Data.DList as DList
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Debug.Trace
+import PrettyPrint
+import Telomare (FragExpr (..), FragExprUR (..), FragIndex (..),
+                 PartialType (..), PrettyPartialType (PrettyPartialType),
+                 RecursionSimulationPieces (..), Term3 (..), rootFrag)
 
 debug :: Bool
 debug = False


### PR DESCRIPTION
Removes default setting of aligning imports for better git diff