### PR TITLE
Fix directory reference of haddock documentation

### DIFF
--- a/.github/workflows/telomare-ci.yml
+++ b/.github/workflows/telomare-ci.yml
@@ -98,7 +98,7 @@ jobs:
           ls
           rm -rf stand-in-language.github.io/docs/haddock/
           mkdir stand-in-language.github.io/docs/haddock/
-          cp -r telomare/dist-newstyle/build/x86_64-linux/ghc-9.2.2/telomare-0.1.0.0/doc/html/telomare/. stand-in-language.github.io/docs/haddock
+          cp -r telomare/dist-newstyle/build/x86_64-linux/ghc-9.2.4/telomare-0.1.0.0/doc/html/telomare/. stand-in-language.github.io/docs/haddock
       - uses: EndBug/add-and-commit@v7
         with:
           message: 'haddock documentation automatically updated'


### PR DESCRIPTION
Change in the ghc version broke where the generated haddock documentation is copied from, this fixes that.