### PR TITLE
Change formatting workflow

### DIFF
--- a/.github/workflows/telomare-ci.yml
+++ b/.github/workflows/telomare-ci.yml
@@ -34,15 +34,11 @@ jobs:
         echo ${{ github.ref }}
         echo ${{ github.repository }}
   format:
-    if: ${{ (github.ref == 'refs/heads/master') && (github.repository == 'Stand-In-Language/stand-in-language') }}
     needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout telomare repository
         uses: actions/checkout@v3
-        with:
-          repository: Stand-In-Language/stand-in-language
-          token: ${{ secrets.API_TOKEN_GITHUB }}
       - uses: cachix/install-nix-action@v20
         with:
           extra_nix_config: |
@@ -54,13 +50,15 @@ jobs:
           extraPullNames: nix-community
       - name: stylish-haskell formatting
         run: |
-          ls
           nix develop -c stylish-haskell -irv .
-          echo stylish-haskell formatting finished
-      - uses: EndBug/add-and-commit@v7
-        with:
-          message: 'stylish-haskell formatting automatically applied'
-          default_author: github_actions
+          output=$(git diff)
+          if [ "$output" = "" ]; then
+              echo "Success! No formatting suggestions."
+          else
+              echo "Failure: stylish-haskell has some formatting suggestions:"
+              echo "$output"
+              exit 1
+          fi
   lint:
     needs: tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fails when suggestions by stylish-haskell are found and succeeds if there are no suggestions. Will not commit any changes. Also works on forks and not only on the base repo: so the need of formatting is evident on your wip and not until it is merged to the base repo.