### PR TITLE
Have format and lint check always done

### DIFF
--- a/.github/workflows/telomare-ci.yml
+++ b/.github/workflows/telomare-ci.yml
@@ -34,7 +34,6 @@ jobs:
         echo ${{ github.ref }}
         echo ${{ github.repository }}
   format:
-    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout telomare repository
@@ -60,7 +59,6 @@ jobs:
               exit 1
           fi
   lint:
-    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout telomare repository


### PR DESCRIPTION
Gives developer more feedback: if you have linting or formatting suggestions, you'll know regardless of the test suite being successful

Came across this because my emacs' hls is currently down and it would be nice to know from CI if there is any formatting or linting necessary, but I couldn't know because I added a test that currently fails on master, and there is no reason why to restrict it this way.