### PR TITLE
Fix `cabal test`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
           program = self.packages.${system}.telomare + "/bin/telomare-repl";
         };
 
-        devShells.default = project false "telomare-with-tools" (with compiler; [ # [4]
+        devShells.default = project true "telomare-with-tools" (with compiler; [ # [4]
           cabal-install
           haskell-language-server
           hlint


### PR DESCRIPTION
Resolves this error triggered by `cabal test`:
"the test suite 'telomare-test', the test suite 'telomare-resolver-test' and the test suite 'telomare-parser-test' are not available because the solver picked a plan that does not include the test suites"