### PR TITLE
Fix release stage of ci

### DIFF
--- a/.github/workflows/telomare-ci.yml
+++ b/.github/workflows/telomare-ci.yml
@@ -121,6 +121,7 @@ jobs:
         run: |
           ls
           cd telomare
+          nix -Lv develop -c cabal update
           (nix develop -c cabal haddock --haddock-hyperlink-source) > ../haddock-output
           echo OK Haddock build
       - name: haddock copy


### PR DESCRIPTION
Error was:
```
Error: [Cabal-7160]
The package list for 'hackage.haskell.org' does not exist. Run 'cabal update' to download it.

Error: Process completed with exit code 1.
```